### PR TITLE
Re-added in plots for GADM data, separated out GADM sub-pipeline, fix…

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -77,7 +77,13 @@ uv run dart-pipeline process geospatial/era5-reanalysis dataset=derived-era5-lan
 ```
 uv run dart-pipeline get geospatial/gadm 3=PER
 uv run dart-pipeline get geospatial/gadm 3=VNM
+uv run dart-pipeline get geospatial/gadm 3=VNM --unpack
 uv run dart-pipeline process geospatial/gadm 3=VNM a=0
+uv run dart-pipeline process geospatial/gadm 3=VNM a=1
+uv run dart-pipeline process geospatial/gadm 3=VNM a=0 l=INFO plots
+uv run dart-pipeline process geospatial/gadm 3=VNM a=1 l=INFO plots
+uv run dart-pipeline process geospatial/gadm 3=VNM a=2 l=INFO plots
+uv run dart-pipeline process geospatial/gadm 3=VNM a=3 l=INFO plots
 ```
 
 ### WorldPop Population Counts

--- a/RUNTIMES.md
+++ b/RUNTIMES.md
@@ -98,9 +98,24 @@ time uv run dart-pipeline process geospatial/era5-reanalysis dataset=derived-era
 ### Global Administrative Areas (GADM)
 
 ```
+time uv run dart-pipeline get geospatial/gadm 3=PER --unpack
+26.031s
 time uv run dart-pipeline get geospatial/gadm 3=VNM
-17.964s
+36.831s
+time uv run dart-pipeline get geospatial/gadm 3=VNM --unpack
+22.101s
 time uv run dart-pipeline process geospatial/gadm 3=VNM a=0
+1.913s
+time uv run dart-pipeline process geospatial/gadm 3=VNM a=1
+1.871s
+time uv run dart-pipeline process geospatial/gadm 3=VNM a=0 l=INFO plots
+2.055s
+time uv run dart-pipeline process geospatial/gadm 3=VNM a=1 l=INFO plots
+2.145s
+time uv run dart-pipeline process geospatial/gadm 3=VNM a=2 l=INFO plots
+2.742s
+time uv run dart-pipeline process geospatial/gadm 3=VNM a=3 l=INFO plots
+18.716s
 ```
 
 ### WorldPop Population Counts

--- a/src/dart_pipeline/INDEX.md
+++ b/src/dart_pipeline/INDEX.md
@@ -8,6 +8,8 @@ geospatial/aphroditetemperature.py
 ✅ def process_gadm_aphroditetemperature(
 geospatial/era5reanalysis.py
 ✅ def process_gadm_era5reanalysis(
+geospatial/gadm.py
+✅ def process_gadm(iso3: str, admin_level: AdminLevel):
 geospatial/worldpop_count.py
 ✅ def process_gadm_worldpopcount(
 geospatial/worldpop_density.py
@@ -79,7 +81,6 @@ def worldpop_pop_count_data(iso3: str) -> URLCollection:
 def process_rwi(iso3: str, admin_level: str, plots=False):
 ✅ def process_dengueperu(
 ✅ def process_gadm_chirps_rainfall(
-def process_gadm_admin_map_data(iso3: str, admin_level: AdminLevel):
 def get_chirps_rainfall_data_path(date: PartialDate) -> Path:
 def process_chirps_rainfall(partial_date: str, plots=False) -> ProcessResult:
 def process_terraclimate(

--- a/src/dart_pipeline/collate.py
+++ b/src/dart_pipeline/collate.py
@@ -51,7 +51,7 @@ from .types import URLCollection, DataFile, PartialDate
 from .util import daterange, use_range, get_country_name
 
 
-def gadm_data(iso3: str) -> URLCollection:
+def gadm(iso3: str) -> URLCollection:
     """
     Get URLs for GADM (Database of Global Administrative Areas) data.
 
@@ -403,7 +403,7 @@ SOURCES: dict[
 ] = {
     'economic/relative-wealth-index': relative_wealth_index,
     'epidemiological/dengue/peru': ministerio_de_salud_peru_data,
-    'geospatial/gadm': gadm_data,
+    'geospatial/gadm': gadm,
     'meteorological/aphrodite-daily-mean-temp': aphrodite_temperature_data,
     'meteorological/aphrodite-daily-precip': aphrodite_precipitation_data,
     'meteorological/chirps-rainfall': chirps_rainfall_data,

--- a/src/dart_pipeline/geospatial/gadm.py
+++ b/src/dart_pipeline/geospatial/gadm.py
@@ -7,7 +7,7 @@ from matplotlib import pyplot as plt
 import geopandas as gpd
 import pandas as pd
 
-from dart_pipeline.constants import BASE_DIR, OUTPUT_COLUMNS
+from dart_pipeline.constants import OUTPUT_COLUMNS
 from dart_pipeline.util import get_shapefile, get_country_name, output_path
 from dart_pipeline.types import AdminLevel
 
@@ -44,22 +44,18 @@ def process_gadm(iso3: str, admin_level: AdminLevel, plots=False):
 
         # Populate a row for the output data frame
         df.loc[i, 'admin_level_0'] = region['COUNTRY']
-        region_name = region['COUNTRY']
         # Update the new row and the region name if the admin level is high
         # enough
         if int(admin_level) >= 1:
             df.loc[i, 'admin_level_1'] = region['NAME_1']
-            region_name = region['NAME_1']
         else:
             df.loc[i, 'admin_level_1'] = None
         if int(admin_level) >= 2:
             df.loc[i, 'admin_level_2'] = region['NAME_2']
-            region_name = region['NAME_2']
         else:
             df.loc[i, 'admin_level_2'] = None
         if int(admin_level) >= 3:
             df.loc[i, 'admin_level_3'] = region['NAME_3']
-            region_name = region['NAME_3']
         else:
             df.loc[i, 'admin_level_3'] = None
 

--- a/src/dart_pipeline/geospatial/gadm.py
+++ b/src/dart_pipeline/geospatial/gadm.py
@@ -1,0 +1,111 @@
+"""Module for processing Database of Global Administrative Areas data."""
+from datetime import date
+from pathlib import Path
+import logging
+
+from matplotlib import pyplot as plt
+import geopandas as gpd
+import pandas as pd
+
+from dart_pipeline.constants import BASE_DIR, OUTPUT_COLUMNS
+from dart_pipeline.util import get_shapefile, get_country_name, output_path
+from dart_pipeline.types import AdminLevel
+
+
+def process_gadm(iso3: str, admin_level: AdminLevel, plots=False):
+    """Process GADM administrative map data."""
+    sub_pipeline = 'geospatial/gadm'
+    iso3 = iso3.upper()
+    logging.info('iso3:%s', iso3)
+    logging.info('admin_level:%s', admin_level)
+    logging.info('plots:%s', plots)
+
+    # Import
+    gdf = gpd.read_file(get_shapefile(iso3, admin_level))
+
+    # Re-project the data
+    # https://spatialreference.org/
+    national_crs = {
+        'GBR': 27700,  # EPSG:27700 - OSGB36/British National Grid
+        'PER': 24892,  # EPSG:24892 - PSAD56/Peru central zone
+        'VNM': 2045,  # EPSG:2045 - Hanoi 1972/Gauss-Kruger zone 19
+    }
+    try:
+        gdf = gdf.to_crs(epsg=national_crs[iso3])
+    except KeyError:
+        pass
+
+    # Initialise the output data frame
+    df = pd.DataFrame(columns=OUTPUT_COLUMNS)
+
+    # Iterate over the regions in the shape file
+    for i, region in gdf.iterrows():
+        df.loc[i, 'iso3'] = iso3
+
+        # Populate a row for the output data frame
+        df.loc[i, 'admin_level_0'] = region['COUNTRY']
+        region_name = region['COUNTRY']
+        # Update the new row and the region name if the admin level is high
+        # enough
+        if int(admin_level) >= 1:
+            df.loc[i, 'admin_level_1'] = region['NAME_1']
+            region_name = region['NAME_1']
+        else:
+            df.loc[i, 'admin_level_1'] = None
+        if int(admin_level) >= 2:
+            df.loc[i, 'admin_level_2'] = region['NAME_2']
+            region_name = region['NAME_2']
+        else:
+            df.loc[i, 'admin_level_2'] = None
+        if int(admin_level) >= 3:
+            df.loc[i, 'admin_level_3'] = region['NAME_3']
+            region_name = region['NAME_3']
+        else:
+            df.loc[i, 'admin_level_3'] = None
+
+        # Populate the year and month
+        df.loc[i, 'year'] = None
+        df.loc[i, 'month'] = None
+        df.loc[i, 'day'] = None
+        df.loc[i, 'week'] = None
+
+        # Calculate area in square metres
+        area = region.geometry.area
+        # Convert to square kilometres
+        area_sq_km = area / 1e6
+
+        # Add to output data frame
+        df.loc[i, 'metric'] = 'area'
+        df.loc[i, 'value'] = area_sq_km
+        df.loc[i, 'unit'] = 'km²'
+        df.loc[i, 'resolution'] = None
+        df.loc[i, 'creation_date'] = date.today()
+
+    if plots:
+        # Re-project to a geographic coordinate system (GCS)
+        gdf = gdf.to_crs(epsg=4326)
+        # Plot only the boundaries (without filling regions)
+        fig, ax = plt.subplots(figsize=(10, 6))
+        gdf.boundary.plot(ax=ax, color='black', linewidth=1)
+        country_name = get_country_name(iso3)
+        title = f'{country_name}\nAdmin Level {admin_level}'
+        ax.set_title(title)
+        ax.set_xlabel('Longitude')
+        ax.set_ylabel('Latitude')
+        # Ensure x/y limits are properly set
+        if not gdf.empty and gdf.total_bounds.any():
+            ax.set_xlim(gdf.total_bounds[0], gdf.total_bounds[2])
+            ax.set_ylim(gdf.total_bounds[1], gdf.total_bounds[3])
+        # Export
+        path = Path(
+            output_path(sub_pipeline), str(iso3),
+            f'{country_name} - Admin Level {admin_level}.png'
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        logging.info('exporting:%s', path)
+        plt.savefig(path)
+        plt.close()
+
+    sub_pipeline = sub_pipeline.replace('/', '_')
+
+    return df.fillna(''), f'{iso3}_{sub_pipeline}_{date.today()}.csv'

--- a/src/dart_pipeline/process.py
+++ b/src/dart_pipeline/process.py
@@ -51,7 +51,7 @@ from .constants import TERRACLIMATE_METRICS, OUTPUT_COLUMNS, BASE_DIR, \
 from .plots import \
     plot_heatmap, plot_gadm_micro_heatmap, plot_gadm_macro_heatmap, \
     plot_timeseries
-from .types import ProcessResult, PartialDate, AdminLevel
+from .types import ProcessResult, PartialDate
 from .util import \
     source_path, output_path, get_country_name, get_shapefile
 

--- a/src/dart_pipeline/util.py
+++ b/src/dart_pipeline/util.py
@@ -323,6 +323,7 @@ def update_or_create_output(
         # Import the existing CSV with everything as a string
         old_df = pd.read_csv(out, dtype=str)
         old_df.fillna('', inplace=True)
+        old_df = old_df.astype(str)
         # Convert the new data frame to str
         new_df = new_df.astype(str)
         new_df.fillna('', inplace=True)

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -26,6 +26,8 @@ pytest tests/test_geospatial_aphroditetemperature.py
 ✅ def test_process_gadm_aphroditetemperature():
 pytest tests/test_geospatial_era5reanalysis.py
 ✅ def test_process_gadm_era5reanalysis(
+pytest tests/test_geospatial_gadm.py
+✅ def test_process_gadm(
 pytest tests/test_geospatial_worldpop_count.py
 ✅ def test_process_gadm_worldpopcount(
 pytest tests/test_geospatial_worldpop_density.py

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -10,7 +10,7 @@ import requests_mock
 
 from dart_pipeline.types import URLCollection
 from dart_pipeline.collate import (
-    gadm_data,
+    gadm,
     relative_wealth_index,
     ministerio_de_salud_peru_data,
     aphrodite_temperature_data,
@@ -23,17 +23,17 @@ from dart_pipeline.collate import (
 
 
 def test_gadm_data():
-    assert gadm_data("VNM") == URLCollection(
-        "https://geodata.ucdavis.edu/gadm/gadm4.1",
+    assert gadm('VNM') == URLCollection(
+        'https://geodata.ucdavis.edu/gadm/gadm4.1',
         [
-            "shp/gadm41_VNM_shp.zip",
-            "gpkg/gadm41_VNM.gpkg",
-            "json/gadm41_VNM_0.json",
-            "json/gadm41_VNM_1.json.zip",
-            "json/gadm41_VNM_2.json.zip",
-            "json/gadm41_VNM_3.json.zip",
+            'shp/gadm41_VNM_shp.zip',
+            'gpkg/gadm41_VNM.gpkg',
+            'json/gadm41_VNM_0.json',
+            'json/gadm41_VNM_1.json.zip',
+            'json/gadm41_VNM_2.json.zip',
+            'json/gadm41_VNM_3.json.zip',
         ],
-        relative_path="VNM",
+        relative_path='VNM',
     )
 
 

--- a/tests/test_geospatial_aphroditeprecipitation.py
+++ b/tests/test_geospatial_aphroditeprecipitation.py
@@ -20,7 +20,7 @@ class MockFile(BytesIO):
 def test_process_gadm_aphroditeprecipitation():
     iso3 = 'VNM'
     admin_level = '0'
-    partial_date = '2023-07'
+    partial_date = '2023-07-11'
     resolution = ['025deg']
     plots = False
 

--- a/tests/test_geospatial_gadm.py
+++ b/tests/test_geospatial_gadm.py
@@ -1,0 +1,55 @@
+"""Tests for process functions in geospatial/gadm.py."""
+from pathlib import Path
+from unittest.mock import patch
+
+from freezegun import freeze_time
+from shapely.geometry import Polygon
+import geopandas as gpd
+
+from dart_pipeline.constants import BASE_DIR
+from dart_pipeline.process import process_gadm
+
+
+@freeze_time('2024-02-17')
+@patch('geopandas.read_file')
+@patch('matplotlib.pyplot.savefig')
+@patch('matplotlib.pyplot.close')
+def test_process_gadm(mock_close, mock_savefig, mock_read_file):
+    # Create a mock GeoDataFrame
+    data = {
+        'COUNTRY': ['Vietnam'],
+        'NAME_1': ['Hanoi'],
+        'NAME_2': ['Ba Dinh'],
+        'NAME_3': ['Phuc Xa'],
+        'geometry': [
+            Polygon(
+                [(105.8, 21.0), (105.9, 21.0), (105.9, 21.1), (105.8, 21.1)]
+            )
+        ]  # Hanoi region
+    }
+    gdf = gpd.GeoDataFrame(data, crs='EPSG:4326')
+    mock_read_file.return_value = gdf
+
+    # Run the function
+    df, output_filename = process_gadm('VNM', '2', plots=True)
+
+    # Assertions
+    expected_filename = 'VNM_geospatial_gadm_2024-02-17.csv'
+    assert output_filename == expected_filename
+
+    # Check data frame contents
+    assert df.shape[0] == 1  # Should have one row
+    assert df.loc[0, 'iso3'] == 'VNM'
+    assert df.loc[0, 'admin_level_0'] == 'Vietnam'
+    assert df.loc[0, 'admin_level_1'] == 'Hanoi'
+    assert df.loc[0, 'admin_level_2'] == 'Ba Dinh'
+    assert df.loc[0, 'admin_level_3'] == ''  # Admin Level 3 not included
+
+    # Check calculated area
+    expected_area_km2 = gdf.geometry.area.iloc[0] / 1e6
+    assert abs(df.loc[0, 'value'] - expected_area_km2) < 200
+
+    # Ensure mocks were called
+    path = Path(BASE_DIR, 'data/sources/geospatial/gadm/VNM/gadm41_VNM_2.shp')
+    mock_read_file.assert_called_once_with(path)
+    mock_savefig.assert_called_once()


### PR DESCRIPTION
DART-Pipeline Developer Documentation
=====================================

Geospatial
----------

### Global Administrative Areas (GADM)

```
uv run dart-pipeline get geospatial/gadm 3=PER
uv run dart-pipeline get geospatial/gadm 3=VNM
uv run dart-pipeline get geospatial/gadm 3=VNM --unpack
uv run dart-pipeline process geospatial/gadm 3=VNM a=0
uv run dart-pipeline process geospatial/gadm 3=VNM a=1
uv run dart-pipeline process geospatial/gadm 3=VNM a=0 l=INFO plots
uv run dart-pipeline process geospatial/gadm 3=VNM a=1 l=INFO plots
uv run dart-pipeline process geospatial/gadm 3=VNM a=2 l=INFO plots
uv run dart-pipeline process geospatial/gadm 3=VNM a=3 l=INFO plots
```

RUNTIMES
========

Geospatial
----------

### Global Administrative Areas (GADM)

```
time uv run dart-pipeline get geospatial/gadm 3=PER --unpack
26.031s
time uv run dart-pipeline get geospatial/gadm 3=VNM
36.831s
time uv run dart-pipeline get geospatial/gadm 3=VNM --unpack
22.101s
time uv run dart-pipeline process geospatial/gadm 3=VNM a=0
1.913s
time uv run dart-pipeline process geospatial/gadm 3=VNM a=1
1.871s
time uv run dart-pipeline process geospatial/gadm 3=VNM a=0 l=INFO plots
2.055s
time uv run dart-pipeline process geospatial/gadm 3=VNM a=1 l=INFO plots
2.145s
time uv run dart-pipeline process geospatial/gadm 3=VNM a=2 l=INFO plots
2.742s
time uv run dart-pipeline process geospatial/gadm 3=VNM a=3 l=INFO plots
18.716s
```

INDEX
=====

```
geospatial/gadm.py
✅ def process_gadm(iso3: str, admin_level: AdminLevel):
```

INDEX (Tests)
=====

```
pytest tests/test_geospatial_gadm.py
✅ def test_process_gadm(
```
