### PR TITLE
feat: add support for bias-corrected total precipitation

### DIFF
--- a/src/dart_pipeline/metrics/era5/derived.py
+++ b/src/dart_pipeline/metrics/era5/derived.py
@@ -41,9 +41,8 @@ def wind_speed(ds: xr.Dataset) -> xr.DataArray:
 
 
 @derived_metric()
-def hydrological_balance(ds: xr.Dataset, bias_corrected=False) -> xr.DataArray:
-    tp_col = "tp_corrected" if bias_corrected else "tp"
-    return ds[tp_col] + ds.e
+def hydrological_balance(ds: xr.Dataset) -> xr.DataArray:
+    return ds.tp + ds.e
 
 
 def compute_derived_metric(metric: str, ds: xr.Dataset, **kwargs):

--- a/src/dart_pipeline/metrics/era5/list_metrics.py
+++ b/src/dart_pipeline/metrics/era5/list_metrics.py
@@ -21,6 +21,7 @@ VARIABLE_MAPPINGS = {
     "surface_pressure": "sp",
     "evaporation": "e",
     "total_precipitation": "tp",
+    "total_precipitation_corrected": "tp_corrected",
     "10m_u_component_of_wind": "u10",
     "10m_v_component_of_wind": "v10",
 }
@@ -87,7 +88,6 @@ METRICS: dict[str, MetricInfo] = {
     },
     "total_precipitation_corrected": {
         "description": "Bias-corrected total precipitation",
-        "depends": ["total_precipitation"],
         "unit": "m",
         "part_of": "era5",
     },
@@ -135,4 +135,4 @@ DERIVED_METRICS_SEPARATE_IMPL = [
     "spi.gamma",
     "spei.gamma",
     "prep_bias_correct",
-] + [m for m in ACCUM_METRICS if m.endswith("_corrected")]
+]


### PR DESCRIPTION
Adds support for reading in *.tp_corrected.nc files prepared by
dart-bias-correct when creating metric outputs. Falls back
to non-bias-corrected outputs if tp_corrected files are not found.
Note that tp_corrected files must be present for successive years
for all timezones other than UTC+1 for timezone shifting.

This does not include SPI and SPEI calculations that take into
account the bias-correction.
