### PR TITLE
chore: update geoglue

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 [[package]]
 name = "geoglue"
 version = "0.1.0"
-source = { git = "https://github.com/kraemer-lab/geoglue#d21b4385387ded7a0333ad7c29fc94787cbbd66d" }
+source = { git = "https://github.com/kraemer-lab/geoglue#fd2ee9b2999b8f4d255bb042c3c453770b1f6cc0" }
 dependencies = [
     { name = "cdo" },
     { name = "cdsapi" },


### PR DESCRIPTION
Run tests to see that empty concatenation fix did not break anything
