### PR TITLE
fix(ecmwf.forecast): load datasets incrementally to avoid NaNs

### DIFF
--- a/src/dart_pipeline/metrics/ecmwf/__init__.py
+++ b/src/dart_pipeline/metrics/ecmwf/__init__.py
@@ -111,11 +111,7 @@ def get_forecast_open_data(
         logger.info("Using already retrieved forecast file: %s", output_path)
     region = gadm(iso3, 1)
     extents = region.bbox.int()
-    sel_kwargs = {
-        "latitude": slice(extents.maxy, extents.miny),
-        "longitude": slice(extents.minx, extents.maxx),
-    }
-    instant, accum = forecast_grib_to_netcdf(forecast_path(date), sel_kwargs)
+    instant, accum = forecast_grib_to_netcdf(forecast_path(date), extents)
     sources_path = get_path("sources", iso3, "ecmwf")
     instant_file = sources_path / f"{iso3}-{date}-ecmwf.forecast.instant.nc"
     accum_file = sources_path / f"{iso3}-{date}-ecmwf.forecast.accum.nc"

--- a/src/dart_pipeline/metrics/ecmwf/forecast.py
+++ b/src/dart_pipeline/metrics/ecmwf/forecast.py
@@ -2,14 +2,13 @@
 
 import logging
 import functools
+import tempfile
 import multiprocessing
 from pathlib import Path
-from typing import Literal
 
 import numpy as np
 import xarray as xr
 import geoglue.zonal_stats
-from tqdm import trange
 from geoglue import MemoryRaster
 from geoglue.types import Bbox
 from geoglue.region import Region
@@ -33,23 +32,6 @@ INSTANT_VARS = ["t2m", "d2m", "sp"]
 ACCUM_VARS = ["tp"]
 
 logger = logging.getLogger(__name__)
-
-
-def cfgrib_open(
-    file: str | Path,
-    dataType: Literal["pf", "cf"],
-    sel: dict,
-    shortName: list[str] | None = None,
-) -> xr.Dataset:
-    filter_by_keys: dict[str, str | list[str]] = {"dataType": dataType}
-    if shortName:
-        filter_by_keys["shortName"] = shortName
-    return xr.open_dataset(
-        file,
-        engine="cfgrib",
-        filter_by_keys=filter_by_keys,
-        decode_timedelta=True,
-    ).sel(**sel)
 
 
 def zonal_stats(
@@ -200,9 +182,7 @@ def forecast_zonal_stats(
     return xr.merge([instant_zs, accum_zs])
 
 
-def forecast_grib_to_netcdf(
-    file: Path, sel_kwargs: dict
-) -> tuple[xr.Dataset, xr.Dataset]:
+def forecast_grib_to_netcdf(file: Path, bbox: Bbox) -> tuple[xr.Dataset, xr.Dataset]:
     """
     This method extracts variables from the GRIB2 file, performs a spatial crop
     (open data is downloaded for the whole world) and saves them in a netcdf file.
@@ -216,59 +196,117 @@ def forecast_grib_to_netcdf(
     ----------
     file : Path
         Path of the GRIB2 file to read
-    sel_kwargs : dict
-        Dictionary with the keywords to select the data, such as lat and lon, for
-        example, for the region of Vietnam it would be
-        ```python
-        sel_kwargs = {"latitude": slice(24, 8), "longitude": slice(102, 110)}
-        ```
-    output_folder : Path
-        Folder to write netCDF files in (default=None). If not specified,
-        writes to standard DART location:
-        ``~/.local/share/dart-pipeline/sources/VNM/ecmwf/``
-    output_stem : str
-        Stem of the output file, usually comprising the iso3 code
-        and date, e.g. VNM-2025-05-16
+    bbox : Bbox
+        Bounding box to select, this is usually obtained from a geoglue Region object
+
+        .. code-block::
+
+            from geoglue.region import gadm
+            region = gadm("VNM", 1)
+            print(region.bbox)
 
     Returns
     -------
     tuple[xr.Dataset, xr.Dataset]
-        Tuple of (instant, accum) xarray Datasets converted from GRIB2 file
+        Tuple of instant and accumulative variables
     """
-    logger.info("Converting from GRIB2 to netCDF: %s", file)
-    pf = cfgrib_open(file, "pf", sel_kwargs)
-    pf_temp = cfgrib_open(file, "pf", sel_kwargs, ["2t", "2d"])
-    n_ensembles = len(pf.number)
-    # Number of simulations processed at once. Trying to process all the data at
-    # once causes the computer to crash so this function determines how many
-    # simulations do we process at once
-    sims = np.arange(1, n_ensembles, 5)
 
-    if n_ensembles not in sims:
-        sims = np.append(sims, n_ensembles)
-
-    # The following opens the grid data, loads all the variable and simulations
-    # and transforms it into a single xarray that is then saved as a netcdf.
-    # This is because xarray does not let load data from different simulations
-    # (control and perturbed forecasts) or variables that are in different levels
-    # (such as 2 meter temperature and surface pressure). Hence we need to load
-    # the datasets separately and then join them together into a single xarray.
-
-    # Read control forecast as ensemble index 0
-    inter_tot = xr.merge(
-        [
-            cfgrib_open(file, "cf", sel_kwargs),
-            cfgrib_open(file, "cf", sel_kwargs, ["2t", "2d"]),
-        ],
-        compat="override",
+    sel_kwargs: dict[str, slice] = {
+        "latitude": bbox.lat_slice,
+        "longitude": bbox.lon_slice,
+    }
+    ensembles_len = len(
+        xr.open_dataset(
+            file,
+            engine="cfgrib",
+            decode_timedelta=True,
+            filter_by_keys={"dataType": "pf"},
+        ).number
     )
-    for i in trange(len(sims) - 1, desc="Converting simulation groups"):
-        number_slice = (
-            slice(sims[0], sims[1]) if i == 0 else slice(sims[i] + 1, sims[i + 1])
-        )
-        pf = xr.merge(
-            [pf.sel(number=number_slice), pf_temp.sel(number=number_slice)],
+    # number of simulations to correct. We start at 1 because control forecast (cf) counts as sim 0
+    sims = np.arange(1, ensembles_len, 5)
+    # and perturbed sim goes to 1 to n
+    if ensembles_len not in sims:
+        sims = np.append(sims, ensembles_len)
+
+    # Loop for extracting data in grib and put it into netcdf. It is important
+    # to note that xarray does not let extract variables from grib that are
+    # considered in different levels (such as surface pressure and two meter
+    # temperature) or simulations (control and perturbed simulations) at the
+    # same time. Hence we need to extract temperatures and the rest of the
+    # variables separately. And the same with control and perturbed simulations
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        logger.info("Extracting control and perturbed forecast (0)")
+        interc = xr.merge(
+            [
+                xr.open_dataset(
+                    file,
+                    engine="cfgrib",
+                    decode_timedelta=True,
+                    filter_by_keys={"dataType": "cf"},
+                ).sel(sel_kwargs),
+                xr.open_dataset(
+                    file,
+                    engine="cfgrib",
+                    decode_timedelta=True,
+                    filter_by_keys={"dataType": "cf", "shortName": ["2t", "2d"]},
+                ).sel(sel_kwargs),
+            ],
             compat="override",
         )
-        inter_tot = xr.concat([inter_tot, pf], dim="number")
-    return inter_tot[INSTANT_VARS], inter_tot[ACCUM_VARS]
+
+        # Load perturbed forecast (pf)
+        interp = xr.merge(
+            [
+                xr.open_dataset(
+                    file,
+                    engine="cfgrib",
+                    decode_timedelta=True,
+                    filter_by_keys={"dataType": "pf"},
+                ).sel(**sel_kwargs, number=slice(sims[0], sims[1])),
+                xr.open_dataset(
+                    file,
+                    engine="cfgrib",
+                    decode_timedelta=True,
+                    filter_by_keys={"dataType": "pf", "shortName": ["2t", "2d"]},
+                ).sel(**sel_kwargs, number=slice(sims[0], sims[1])),
+            ],
+            compat="override",
+        )
+        interp = xr.concat([interc, interp], dim="number")
+        interp.to_netcdf(Path(temp_dir) / "intersim_0.nc")
+        for i in range(1, len(sims) - 1):
+            logger.info("Extracting simulations from %d -- %d", sims[i], sims[i + 1])
+            interp = xr.merge(
+                [
+                    xr.open_dataset(
+                        file,
+                        engine="cfgrib",
+                        decode_timedelta=True,
+                        filter_by_keys={"dataType": "pf"},
+                    ).sel(**sel_kwargs, number=slice(sims[i] + 1, sims[i + 1])),
+                    xr.open_dataset(
+                        file,
+                        engine="cfgrib",
+                        decode_timedelta=True,
+                        filter_by_keys={"dataType": "pf", "shortName": ["2t", "2d"]},
+                    ).sel(**sel_kwargs, number=slice(sims[i] + 1, sims[i + 1])),
+                ],
+                compat="override",
+            )
+            interp.to_netcdf(Path(temp_dir) / f"intersim_{i}.nc")
+
+        ds = xr.open_dataset(Path(temp_dir) / "intersim_0.nc", decode_timedelta=True)
+        for i in range(1, len(sims) - 1):
+            ds = xr.concat(
+                [
+                    ds,
+                    xr.open_dataset(
+                        Path(temp_dir) / f"intersim_{i}.nc", decode_timedelta=True
+                    ),
+                ],
+                dim="number",
+            )  # concatenate intermediate files
+
+    return ds[INSTANT_VARS], ds[ACCUM_VARS]


### PR DESCRIPTION
Previous version put in NaNs, not sure why loading the entire dataset
would cause that -- this way also saves memory.

Co-authored-by: Iago Perez Fernandez <68069957+Winter-23@users.noreply.github.com>
