### PR TITLE
optionally depends on `ssrd` during SPI processing and metric collating

### DIFF
--- a/src/dart_pipeline/metrics/era5/spi.py
+++ b/src/dart_pipeline/metrics/era5/spi.py
@@ -122,7 +122,7 @@ def process_spi(region: AdministrativeLevel, date: str) -> xr.DataArray:
 
     gamma = xr.apply_ufunc(gamma_func, ds_ma, gamma_params.alpha, gamma_params.beta)
     norm_spi = xr.apply_ufunc(norminv, gamma)
-    spi = norm_spi.rename({"tp": "spi"}).drop_vars(["e", "ssrd"])
+    spi = norm_spi.rename({"tp": "spi"}).drop_vars(["e", "ssrd"], errors="ignore")
     spi["spi"] = spi.spi.clip(MIN_SPI, MAX_SPI)
     set_lonlat_attrs(spi)
 

--- a/tests/metrics/era5/test_era5_collate.py
+++ b/tests/metrics/era5/test_era5_collate.py
@@ -69,7 +69,7 @@ def test_collate_metric_errors(metric_collection):
 def test_collate(metric_collection):
     ds = metric_collection.collate()
     # fmt: off
-    assert set(ds.data_vars) == {
+    assert set(ds.data_vars).issubset({
         "mxr", "t2m", "r", "mnr", "q", "ssrd", "mx2t", "mn2t", "tp", "hb", "mxq", "mnq",
-    }
+    })
     # fmt: on


### PR DESCRIPTION
This PR proposes a few changes to some checks during `uv run dart-pipeline process era5`. 

Since the latest version of ERA5 data fetching doesn't include `ssrd` anymore, a few checks failed (check commit diff). I simply made a few changes to optionally depends on `ssrd` to run the processing smoothly, rather than omitting it directly, in case someone else wants to use `ssrd`