### PR TITLE
partial fetch until most recent date if current year is end year

### DIFF
--- a/scripts/fetch_weather.sh
+++ b/scripts/fetch_weather.sh
@@ -25,11 +25,7 @@ if [ "$_fetch_end_year" -gt "$_last_supported_year" ]; then
 fi
 
 if [ "$_fetch_end_year" -eq "$_last_supported_year" ]; then
-  cat << EOF
-Note that data for the current year will be partial. For faster downloads,
-geoglue.cds.ReanalysisSingleLevels.get_current_year() can fetch data by month.
-EOF
-  exit 1
+  echo warn: data for the current year will be partial
 fi
 
 echo -e "\033[1m==> Fetching and processing population data\033[0m"

--- a/src/dart_pipeline/metrics/era5/__init__.py
+++ b/src/dart_pipeline/metrics/era5/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import functools
 import multiprocessing
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -54,13 +55,20 @@ foregoing.""",
 
 
 @register_fetch("era5")
-def era5_fetch(region: ZonedBaseRegion, date: str) -> CdsPath | None:
+def era5_fetch(region: ZonedBaseRegion, date: str) -> CdsPath | list[CdsPath] | None:
+    cur_year = datetime.now().year
     year = int(date)
     prompt_cdsapi_key()
     data = ReanalysisSingleLevels(
         region, VARIABLES, path=get_path("sources", region.name, "era5")
     )
-    return data.get(year)
+    if year == cur_year:
+        return data.get_current_year(
+            datetime.strptime(f"{year}/01/01", "%Y/%m/%d").date(),
+            datetime.today().date(),
+        )
+    else:
+        return data.get(year)
 
 
 @register_process("era5.prep_bias_correct", multiple_years=True)


### PR DESCRIPTION
Allow partial fetching of ERA5 data from start of year to most recent date if the year is current year

Shouldn't affect anything else if the `_fetch_end_year` isn't the current year