### PR TITLE
add new recode_region function that will recode regions from indices to GID names

### DIFF
--- a/src/dart_pipeline/metrics/era5/__init__.py
+++ b/src/dart_pipeline/metrics/era5/__init__.py
@@ -28,6 +28,7 @@ from .util import (
     relative_humidity_from_arrays,
     parse_year_range,
     missing_tp_corrected_files,
+    recode_region,
 )
 from .list_metrics import (
     METRICS,
@@ -317,6 +318,7 @@ def process_era5(
             ds.attrs["DART_region"] = (
                 f"{region.name} {region.pk} {region.tz} {region.bbox.int()}"
             )
+            ds = recode_region(ds, region)
             ds.to_netcdf(output)
             return [output]
         case "daily":

--- a/src/dart_pipeline/metrics/era5/__init__.py
+++ b/src/dart_pipeline/metrics/era5/__init__.py
@@ -19,7 +19,7 @@ from ...metrics import (
     print_paths,
 )
 from ...metrics.worldpop import get_worldpop
-from ...util import get_region, msg
+from ...util import get_region, msg, recode_region
 from ...paths import get_path
 
 from .util import (
@@ -28,7 +28,6 @@ from .util import (
     relative_humidity_from_arrays,
     parse_year_range,
     missing_tp_corrected_files,
-    recode_region,
 )
 from .list_metrics import (
     METRICS,

--- a/src/dart_pipeline/metrics/era5/util.py
+++ b/src/dart_pipeline/metrics/era5/util.py
@@ -473,3 +473,12 @@ def standardized_precipitation(
             return norm_spi[tp].rename(var)
         case "spei":
             return norm_spi.rename(var)
+
+
+def recode_region(
+    ds: xr.Dataset | xr.DataArray, region: AdministrativeLevel
+) -> xr.Dataset | xr.DataArray:
+    geom = region.read()
+    gid_lookup = geom.reset_index(drop=True)[region.pk].astype(str).to_numpy()
+
+    return ds.assign_coords(region=("region", gid_lookup))

--- a/src/dart_pipeline/metrics/era5/util.py
+++ b/src/dart_pipeline/metrics/era5/util.py
@@ -25,7 +25,7 @@ from geoglue.cds import (
     DatasetPool,
 )
 from geoglue.util import get_first_monday
-from geoglue.region import ZonedBaseRegion, AdministrativeLevel
+from geoglue.region import ZonedBaseRegion
 
 from ...paths import get_path
 from .list_metrics import VARIABLES
@@ -474,11 +474,3 @@ def standardized_precipitation(
         case "spei":
             return norm_spi.rename(var)
 
-
-def recode_region(
-    ds: xr.Dataset | xr.DataArray, region: AdministrativeLevel
-) -> xr.Dataset | xr.DataArray:
-    geom = region.read()
-    gid_lookup = geom.reset_index(drop=True)[region.pk].astype(str).to_numpy()
-
-    return ds.assign_coords(region=("region", gid_lookup))

--- a/src/dart_pipeline/metrics/era5/util.py
+++ b/src/dart_pipeline/metrics/era5/util.py
@@ -25,7 +25,7 @@ from geoglue.cds import (
     DatasetPool,
 )
 from geoglue.util import get_first_monday
-from geoglue.region import ZonedBaseRegion
+from geoglue.region import ZonedBaseRegion, AdministrativeLevel
 
 from ...paths import get_path
 from .list_metrics import VARIABLES

--- a/src/dart_pipeline/util.py
+++ b/src/dart_pipeline/util.py
@@ -290,3 +290,11 @@ def unpack_file(path: Path | str, same_folder: bool = False):
         case _:
             extract_dir = path.parent if same_folder else path.parent / path.stem
             shutil.unpack_archive(path, str(extract_dir))
+
+def recode_region(
+    ds: xr.Dataset | xr.DataArray, region: geoglue.region.AdministrativeLevel
+) -> xr.Dataset | xr.DataArray:
+    geom = region.read()
+    gid_lookup = geom.reset_index(drop=True)[region.pk].astype(str).to_numpy()
+
+    return ds.assign_coords(region=("region", gid_lookup))


### PR DESCRIPTION
Since `geoglue.zonalstats.zonalstats()` doesn't reassign the region column using `region.pk` anymore (compared to the deprecated `geoglue.zonal_stats.zonal_stats()`), the resulting NetCDF files has a region dim containing only the indices, not the actual GID names

This PR add a new and simple `recode_region()` function that will recode, or reassign, the region dim from indices to the actual GID names. This function is used by default after collating ERA5 metrics