### PR TITLE
Rename whichever datetime dim is used, instead of hardcoding "date"

### DIFF
--- a/src/dart_pipeline/metrics/era5/core_weekly.py
+++ b/src/dart_pipeline/metrics/era5/core_weekly.py
@@ -102,15 +102,17 @@ def zonal_stats(var: str, ds: xr.Dataset, region: AdministrativeLevel) -> xr.Dat
         if var in ["tp", "tp_bc", "hb", "hb_bc"]
         else "mean(coverage_weight=area_spherical_km2)"
     )
-    da = (
-        zonalstats(ds[var], geom, operation, weights)
-        .astype("float32")
-        .rename({"date": "time"})
-        .rename(var)
-    )
+    da = zonalstats(ds[var], geom, operation, weights).astype("float32").rename(var)
+
+    for dt_name in ("date", "valid_time"):
+        if (dt_name in da.dims) or (dt_name in da.coords):
+            da = da.rename({dt_name: "time"})
+            break
+
     if var in ["r", "mxr24", "mnr24"]:
         da = da.clip(0, 100)
     da.assign_attrs(get_cfattrs(var))
+
     return da
 
 


### PR DESCRIPTION
A simple fix resolving #331 

Check for either "date" or "valid_time" dim name then rename it to "time", based on whichever is used